### PR TITLE
update serde dep to v1.122

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 [[package]]
 name = "signatory"
 version = "0.20.0"
-source = "git+https://github.com/ChorusOne/signatory.git?branch=develop#144add7d67a9efb3911d7b9d346a1be77a1cdd91"
+source = "git+https://github.com/ChorusOne/signatory.git?tag=v0.20.1#144add7d67a9efb3911d7b9d346a1be77a1cdd91"
 dependencies = [
  "ecdsa",
  "ed25519",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "signatory-dalek"
 version = "0.20.1"
-source = "git+https://github.com/ChorusOne/signatory.git?branch=develop#144add7d67a9efb3911d7b9d346a1be77a1cdd91"
+source = "git+https://github.com/ChorusOne/signatory.git?tag=v0.20.1#144add7d67a9efb3911d7b9d346a1be77a1cdd91"
 dependencies = [
  "digest 0.8.1",
  "ed25519-dalek",

--- a/src/types/signature.rs
+++ b/src/types/signature.rs
@@ -2,7 +2,6 @@
 use base64;
 use core::fmt;
 use serde::de::Visitor;
-use serde::export::Formatter;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(PartialEq, Debug, Clone)]
@@ -32,7 +31,7 @@ impl<'de> Deserialize<'de> for Signature {
         impl<'de> Visitor<'de> for SignatureVisitor {
             type Value = Signature;
 
-            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("base64 encoded array of bytes")
             }
 

--- a/src/types/validator.rs
+++ b/src/types/validator.rs
@@ -13,7 +13,6 @@ use crate::types::vote::power::Power as VotePower;
 use core::fmt;
 use prost_amino_derive::Message;
 use serde::de::{SeqAccess, Visitor};
-use serde::export::Formatter;
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use signatory::{
@@ -70,7 +69,7 @@ where
         {
             type Value = Set<V>;
 
-            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("sequence of objects implementing Validator trait")
             }
 


### PR DESCRIPTION
### Issue
cargo pulls the latest serde version (v1.122) due to `serde = "1.0"` toml entry. As of some version down the line, serde::export is a private module, so we can't use formatter from there.

The legit way to do it now is simply to switch to `fmt::Formatter`:
https://github.com/serde-rs/serde/blob/dfeaf77bb2a23b00ab18d5af49ed0666075eabe5/serde/src/de/impls.rs#L22

### How it was tested?
1. cargo build
2. cargo test