### PR TITLE
Remove signatory dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
+name = "bitvec"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2838fdd79e8776dbe07a106c784b0f8dda571a21b2750a092cc4cbaa653c8e"
+dependencies = [
+ "funty",
+ "radium",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,10 +152,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d82796b70971fbb603900a5edc797a4d9be0f9ec1257f83a1dba0aa374e3e9"
+
+[[package]]
 name = "cpuid-bool"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d375c433320f6c5057ae04a04376eef4d04ce2801448cf8863a78da99107be4"
+
+[[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+dependencies = [
+ "generic-array 0.14.2",
+ "subtle",
+]
 
 [[package]]
 name = "curve25519-dalek"
@@ -157,6 +184,15 @@ dependencies = [
  "rand_core",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
+dependencies = [
+ "const-oid",
 ]
 
 [[package]]
@@ -188,11 +224,12 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.8.5"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87bf8bfb05ea8a6f74ddf48c7d1774851ba77bbe51ac984fdfa6c30310e1ff5f"
+checksum = "41fbdb4ff710acb4db8ca29f93b897529ea6d6a45626d5183b47e012aa6ae7e4"
 dependencies = [
  "elliptic-curve",
+ "hmac",
  "signature",
 ]
 
@@ -227,12 +264,16 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.6.6"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396db09c483e7fca5d4fdb9112685632b3e76c9a607a2649c1bf904404a01366"
+checksum = "592b1c857559479c056b73a3053c717108a70e4dce320ad28c79c63f5c2e62ba"
 dependencies = [
+ "bitvec",
  "digest 0.9.0",
+ "ff",
  "generic-array 0.14.2",
+ "group",
+ "pkcs8",
  "rand_core",
  "subtle",
  "zeroize",
@@ -252,6 +293,23 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "ff"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
+dependencies = [
+ "bitvec",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "generator"
@@ -312,6 +370,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
+name = "group"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,14 +407,13 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "k256"
-version = "0.5.10"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3934640b1efbc660af5889d041854b6985d403771dc4d5fee984e13e8f82f313"
+checksum = "cf02ecc966e1b7e8db1c81ac8f321ba24d1cfab5b634961fab10111f015858e1"
 dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.9.1",
 ]
 
 [[package]]
@@ -411,6 +489,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "pkcs8"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
+dependencies = [
+ "der",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +563,12 @@ checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2 1.0.18",
 ]
+
+[[package]]
+name = "radium"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64de9a0c5361e034f1aefc9f71a86871ec870e766fe31a009734a989b329286a"
 
 [[package]]
 name = "rand"
@@ -636,21 +729,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signatory"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "674dfa3a5b97b62e039b9e9d94f23887c6b474a7294f272a10327d65af2c8001"
-dependencies = [
- "ecdsa",
- "ed25519",
- "getrandom",
- "k256",
- "signature",
- "subtle-encoding",
- "zeroize",
-]
-
-[[package]]
 name = "signature"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,19 +736,6 @@ checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 dependencies = [
  "digest 0.9.0",
  "rand_core",
- "signature_derive",
-]
-
-[[package]]
-name = "signature_derive"
-version = "1.0.0-pre.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0656c180103507cca4b82519908e813225b2f6b90b2bd59ee119f46155ae872"
-dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.7",
- "syn 1.0.33",
- "synstructure",
 ]
 
 [[package]]
@@ -731,6 +796,8 @@ dependencies = [
  "chrono",
  "clear_on_drop",
  "ed25519-dalek",
+ "elliptic-curve",
+ "k256",
  "prost-amino",
  "prost-amino-derive",
  "rand",
@@ -740,7 +807,6 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "sha2 0.8.2",
- "signatory",
  "subtle",
  "subtle-encoding",
  "thiserror",
@@ -827,6 +893,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 [[package]]
 name = "signatory"
 version = "0.20.0"
-source = "git+https://github.com/ChorusOne/signatory.git?branch=develop#144add7d67a9efb3911d7b9d346a1be77a1cdd91"
+source = "git+https://github.com/ChorusOne/signatory.git?tag=v0.20.1#144add7d67a9efb3911d7b9d346a1be77a1cdd91"
 dependencies = [
  "ecdsa",
  "ed25519",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "signatory-dalek"
 version = "0.20.1"
-source = "git+https://github.com/ChorusOne/signatory.git?branch=develop#144add7d67a9efb3911d7b9d346a1be77a1cdd91"
+source = "git+https://github.com/ChorusOne/signatory.git?tag=v0.20.1#144add7d67a9efb3911d7b9d346a1be77a1cdd91"
 dependencies = [
  "digest 0.8.1",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05100821de9e028f12ae3d189176b41ee198341eb8f369956407fea2f5cc666c"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "miniz_oxide",
  "object",
@@ -114,6 +114,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "chrono"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,12 +148,12 @@ checksum = "6d375c433320f6c5057ae04a04376eef4d04ce2801448cf8863a78da99107be4"
 
 [[package]]
 name = "curve25519-dalek"
-version = "2.1.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
+checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
 dependencies = [
  "byteorder",
- "digest 0.8.1",
+ "digest 0.9.0",
  "rand_core",
  "subtle",
  "zeroize",
@@ -182,13 +188,11 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.6.1"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb6ba8a681d3a9c48875d277f2b11c81934ad690a60a20bcc4eef500ff68e25d"
+checksum = "87bf8bfb05ea8a6f74ddf48c7d1774851ba77bbe51ac984fdfa6c30310e1ff5f"
 dependencies = [
  "elliptic-curve",
- "k256",
- "sha2 0.9.1",
  "signature",
 ]
 
@@ -203,14 +207,16 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.0-pre.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "clear_on_drop",
  "curve25519-dalek",
+ "ed25519",
  "rand",
- "sha2 0.8.2",
+ "serde",
+ "sha2 0.9.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -221,12 +227,13 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.4.0"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2298f66754d859f4c099b0e645cfd258d2dfdfd1bac9496fd514d603ff6a5c6b"
+checksum = "396db09c483e7fca5d4fdb9112685632b3e76c9a607a2649c1bf904404a01366"
 dependencies = [
+ "digest 0.9.0",
  "generic-array 0.14.2",
- "getrandom",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -293,7 +300,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
 ]
@@ -321,11 +328,14 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "k256"
-version = "0.3.0"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f5cb67f9625a99c159fc0776e75d2e37f988cdf31c115e9c25225e61d858c"
+checksum = "3934640b1efbc660af5889d041854b6985d403771dc4d5fee984e13e8f82f313"
 dependencies = [
+ "cfg-if 1.0.0",
+ "ecdsa",
  "elliptic-curve",
+ "sha2 0.9.1",
 ]
 
 [[package]]
@@ -340,7 +350,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -349,7 +359,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ecc775857611e1df29abba5c41355cdf540e7e9d4acfdf0f355eefee82330b7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "generator",
  "scoped-tls",
 ]
@@ -619,7 +629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 0.1.10",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -627,42 +637,47 @@ dependencies = [
 
 [[package]]
 name = "signatory"
-version = "0.20.0"
-source = "git+https://github.com/ChorusOne/signatory.git?tag=v0.20.1#144add7d67a9efb3911d7b9d346a1be77a1cdd91"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "674dfa3a5b97b62e039b9e9d94f23887c6b474a7294f272a10327d65af2c8001"
 dependencies = [
  "ecdsa",
  "ed25519",
  "getrandom",
+ "k256",
  "signature",
  "subtle-encoding",
  "zeroize",
 ]
 
 [[package]]
-name = "signatory-dalek"
-version = "0.20.1"
-source = "git+https://github.com/ChorusOne/signatory.git?tag=v0.20.1#144add7d67a9efb3911d7b9d346a1be77a1cdd91"
+name = "signature"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 dependencies = [
- "digest 0.8.1",
- "ed25519-dalek",
- "sha2 0.8.2",
- "signatory",
+ "digest 0.9.0",
+ "rand_core",
+ "signature_derive",
 ]
 
 [[package]]
-name = "signature"
-version = "1.1.0"
+name = "signature_derive"
+version = "1.0.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65211b7b6fc3f14ff9fc7a2011a434e3e6880585bd2e9e9396315ae24cbf7852"
+checksum = "b0656c180103507cca4b82519908e813225b2f6b90b2bd59ee119f46155ae872"
 dependencies = [
- "digest 0.9.0",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
+ "synstructure",
 ]
 
 [[package]]
 name = "subtle"
-version = "2.2.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "subtle-encoding"
@@ -696,6 +711,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
+ "unicode-xid 0.2.1",
+]
+
+[[package]]
 name = "tendermint_light_client"
 version = "0.3.0"
 dependencies = [
@@ -703,6 +730,7 @@ dependencies = [
  "base64",
  "chrono",
  "clear_on_drop",
+ "ed25519-dalek",
  "prost-amino",
  "prost-amino-derive",
  "rand",
@@ -713,7 +741,6 @@ dependencies = [
  "serde_repr",
  "sha2 0.8.2",
  "signatory",
- "signatory-dalek",
  "subtle",
  "subtle-encoding",
  "thiserror",
@@ -806,3 +833,18 @@ name = "zeroize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
+ "synstructure",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "tendermint_light_client"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Parth Desai <desaiparth08@gmail.com>", "Joe Bowman <joe@chorus.one>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ chrono = { version = "0.4.11", features = ["serde"] }
 serde_derive = "1.0"
 subtle = "2.2"
 thiserror = "1.0.19"
-signatory = { version = "0.22.0", features = ["ed25519", "ecdsa", "k256"] }
+k256 = { version = "0.7.2", features = ["ecdsa"] }
+elliptic-curve = "0.8.4"
 ed25519-dalek = "1.0.1"
 ripemd160 = "0.8.0"
 serde_repr = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ chrono = { version = "0.4.11", features = ["serde"] }
 serde_derive = "1.0"
 subtle = "2.2"
 thiserror = "1.0.19"
-signatory = { version = "0.20.0", features = ["ed25519", "ecdsa", "k256"], git = "https://github.com/ChorusOne/signatory.git", tag = "v0.20.1" }
-signatory-dalek = { version = "0.20.1", git = "https://github.com/ChorusOne/signatory.git", tag = "v0.20.1" }
+signatory = { version = "0.22.0", features = ["ed25519", "ecdsa", "k256"] }
+ed25519-dalek = "1.0.1"
 ripemd160 = "0.8.0"
 serde_repr = "0.1.5"
 sha2 = { version = "0.8", default-features = false }

--- a/src/types/account.rs
+++ b/src/types/account.rs
@@ -2,12 +2,12 @@ use crate::errors::{Error, Kind};
 use ripemd160::Ripemd160;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
-use signatory::{ecdsa::secp256k1};
 use std::fmt;
 use std::fmt::{Debug, Display};
 use std::str::FromStr;
 use subtle::ConstantTimeEq;
 use subtle_encoding::hex;
+use k256::EncodedPoint as Secp256k1;
 
 const LENGTH: usize = 20;
 
@@ -56,8 +56,8 @@ impl Debug for Id {
 }
 
 // RIPEMD160(SHA256(pk))
-impl From<secp256k1::PublicKey> for Id {
-    fn from(pk: secp256k1::PublicKey) -> Id {
+impl From<Secp256k1> for Id {
+    fn from(pk: Secp256k1) -> Id {
         let sha_digest = Sha256::digest(pk.as_bytes());
         let ripemd_digest = Ripemd160::digest(&sha_digest[..]);
         let mut bytes = [0u8; LENGTH];

--- a/src/types/account.rs
+++ b/src/types/account.rs
@@ -2,7 +2,7 @@ use crate::errors::{Error, Kind};
 use ripemd160::Ripemd160;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
-use signatory::{ecdsa::curve::secp256k1, ed25519};
+use signatory::{ecdsa::secp256k1, ed25519};
 use std::fmt;
 use std::fmt::{Debug, Display};
 use std::str::FromStr;

--- a/src/types/account.rs
+++ b/src/types/account.rs
@@ -2,7 +2,7 @@ use crate::errors::{Error, Kind};
 use ripemd160::Ripemd160;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
-use signatory::{ecdsa::secp256k1, ed25519};
+use signatory::{ecdsa::secp256k1};
 use std::fmt;
 use std::fmt::{Debug, Display};
 use std::str::FromStr;
@@ -67,8 +67,8 @@ impl From<secp256k1::PublicKey> for Id {
 }
 
 // SHA256(pk)[:20]
-impl From<ed25519::PublicKey> for Id {
-    fn from(pk: ed25519::PublicKey) -> Id {
+impl From<ed25519_dalek::PublicKey> for Id {
+    fn from(pk: ed25519_dalek::PublicKey) -> Id {
         let digest = Sha256::digest(pk.as_bytes());
         let mut bytes = [0u8; LENGTH];
         bytes.copy_from_slice(&digest[..LENGTH]);

--- a/src/types/pubkey.rs
+++ b/src/types/pubkey.rs
@@ -3,7 +3,7 @@
 use crate::errors::{Error, Kind};
 use anomaly::fail;
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
-use signatory::{ecdsa::secp256k1, ed25519};
+use signatory::{ecdsa::secp256k1};
 use std::{
     fmt::{self, Display},
     ops::Deref,
@@ -15,7 +15,7 @@ use subtle_encoding::{bech32, hex};
 /// Public keys allowed in Tendermint protocols
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type", content = "value")]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum PublicKey {
     /// Ed25519 keys
     #[serde(
@@ -23,7 +23,7 @@ pub enum PublicKey {
         serialize_with = "serialize_ed25519_base64",
         deserialize_with = "deserialize_ed25519_base64"
     )]
-    Ed25519(ed25519::PublicKey),
+    Ed25519(ed25519_dalek::PublicKey),
 
     /// Secp256k1 keys
     #[serde(
@@ -45,11 +45,14 @@ impl PublicKey {
 
     /// From raw Ed25519 public key bytes
     pub fn from_raw_ed25519(bytes: &[u8]) -> Option<PublicKey> {
-        Some(PublicKey::Ed25519(ed25519::PublicKey::from_bytes(bytes)?))
+        match ed25519_dalek::PublicKey::from_bytes(bytes) {
+            Ok(pk) => Some(PublicKey::Ed25519(pk)),
+            Err(_) => None
+        }
     }
 
     /// Get Ed25519 public key
-    pub fn ed25519(self) -> Option<ed25519::PublicKey> {
+    pub fn ed25519(self) -> Option<ed25519_dalek::PublicKey> {
         match self {
             PublicKey::Ed25519(pk) => Some(pk),
             _ => None,
@@ -93,8 +96,8 @@ impl PublicKey {
     }
 }
 
-impl From<ed25519::PublicKey> for PublicKey {
-    fn from(pk: ed25519::PublicKey) -> PublicKey {
+impl From<ed25519_dalek::PublicKey> for PublicKey {
+    fn from(pk: ed25519_dalek::PublicKey) -> PublicKey {
         PublicKey::Ed25519(pk)
     }
 }
@@ -107,7 +110,7 @@ impl From<secp256k1::PublicKey> for PublicKey {
 
 /// Public key roles used in Tendermint networks
 #[allow(dead_code)] // Used in tests
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum TendermintKey {
     /// User signing keys used for interacting with accounts in the state machine
     AccountKey(PublicKey),
@@ -203,7 +206,7 @@ impl<'de> Deserialize<'de> for Algorithm {
 }
 
 /// Serialize the bytes of an Ed25519 public key as Base64. Used for serializing JSON
-fn serialize_ed25519_base64<S>(pk: &ed25519::PublicKey, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_ed25519_base64<S>(pk: &ed25519_dalek::PublicKey, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -225,14 +228,14 @@ where
         .serialize(serializer)
 }
 
-fn deserialize_ed25519_base64<'de, D>(deserializer: D) -> Result<ed25519::PublicKey, D::Error>
+fn deserialize_ed25519_base64<'de, D>(deserializer: D) -> Result<ed25519_dalek::PublicKey, D::Error>
 where
     D: Deserializer<'de>,
 {
     let bytes = base64::decode(String::deserialize(deserializer)?.as_bytes())
         .map_err(|e| D::Error::custom(format!("{}", e)))?;
 
-    ed25519::PublicKey::from_bytes(&bytes).ok_or_else(|| D::Error::custom("invalid ed25519 key"))
+    ed25519_dalek::PublicKey::from_bytes(&bytes).or_else(|_| Err(D::Error::custom("invalid ed25519 key")))
 }
 
 fn deserialize_secp256k1_base64<'de, D>(

--- a/src/types/signature.rs
+++ b/src/types/signature.rs
@@ -2,7 +2,6 @@
 use base64;
 use core::fmt;
 use serde::de::Visitor;
-use serde::export::Formatter;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(PartialEq, Debug, Clone)]
@@ -32,7 +31,7 @@ impl<'de> Deserialize<'de> for Signature {
         impl<'de> Visitor<'de> for SignatureVisitor {
             type Value = Signature;
 
-            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("base64 encoded array of bytes")
             }
 

--- a/src/types/validator.rs
+++ b/src/types/validator.rs
@@ -183,10 +183,8 @@ impl Validator for Info {
     /// public key.
     fn verify_signature(&self, sign_bytes: &[u8], signature: &[u8]) -> bool {
         if let Some(pk) = &self.pub_key.ed25519() {
-            if let Ok(pk) = ed25519_dalek::PublicKey::from_bytes(&pk.into_bytes()) {
-                if let Ok(sig) = ed25519::Signature::from_bytes(signature) {
-                    return pk.verify(sign_bytes, &sig).is_ok()
-                }
+            if let Ok(sig) = ed25519::Signature::from_bytes(signature) {
+                return pk.verify(sign_bytes, &sig).is_ok()
             }
         }
         false
@@ -259,20 +257,14 @@ mod tests {
     use crate::types::traits::validator_set::ValidatorSet;
     use crate::types::validator::{Info, Set};
     use crate::types::vote::power::Power;
-    use rand::Rng;
-    use signatory::ed25519;
-    use std::convert::TryInto;
 
     fn generate_random_validators(number_of_validators: usize, vote_power: u64) -> Vec<Info> {
         let mut vals: Vec<Info> = vec![];
-
         let mut rng = rand::thread_rng();
 
         for _ in 0..number_of_validators {
-            let random_bytes: Vec<u8> = (0..32).map(|_| rng.gen_range(0, 255)).collect();
-            let pub_key = Ed25519(ed25519::PublicKey(
-                random_bytes.as_slice().try_into().unwrap(),
-            ));
+            let keypair: ed25519_dalek::Keypair = ed25519_dalek::Keypair::generate(&mut rng);
+            let pub_key = Ed25519(keypair.public);
             vals.push(Info::new(pub_key, Power::new(vote_power)));
         }
 

--- a/src/types/validator.rs
+++ b/src/types/validator.rs
@@ -15,11 +15,8 @@ use prost_amino_derive::Message;
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use signatory::{
-    ed25519,
-    signature::{Signature},
-};
-use ed25519_dalek::Verifier;
+use ed25519_dalek::{Signature, Verifier};
+use std::convert::TryFrom;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 use std::marker::PhantomData;
@@ -183,7 +180,7 @@ impl Validator for Info {
     /// public key.
     fn verify_signature(&self, sign_bytes: &[u8], signature: &[u8]) -> bool {
         if let Some(pk) = &self.pub_key.ed25519() {
-            if let Ok(sig) = ed25519::Signature::from_bytes(signature) {
+            if let Ok(sig) = Signature::try_from(signature) {
                 return pk.verify(sign_bytes, &sig).is_ok()
             }
         }

--- a/src/types/validator.rs
+++ b/src/types/validator.rs
@@ -13,7 +13,6 @@ use crate::types::vote::power::Power as VotePower;
 use core::fmt;
 use prost_amino_derive::Message;
 use serde::de::{SeqAccess, Visitor};
-use serde::export::Formatter;
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use signatory::{
@@ -70,7 +69,7 @@ where
         {
             type Value = Set<V>;
 
-            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("sequence of objects implementing Validator trait")
             }
 

--- a/src/types/validator.rs
+++ b/src/types/validator.rs
@@ -251,9 +251,11 @@ impl From<&Info> for InfoHashable {
 #[cfg(test)]
 mod tests {
     use crate::types::pubkey::PublicKey::Ed25519;
-    use crate::types::traits::validator_set::ValidatorSet;
+    use crate::types::traits::{validator_set::ValidatorSet, validator::Validator};
     use crate::types::validator::{Info, Set};
     use crate::types::vote::power::Power;
+    use crate::types::pubkey::PublicKey;
+    use subtle_encoding::hex;
 
     fn generate_random_validators(number_of_validators: usize, vote_power: u64) -> Vec<Info> {
         let mut vals: Vec<Info> = vec![];
@@ -313,5 +315,24 @@ mod tests {
         let intersection = first_validator_set.intersect(&second_validator_set);
         assert_eq!(intersection.number_of_validators(), 0);
         assert_eq!(intersection.total_power(), 0);
+    }
+
+    #[test]
+    fn test_validate_signature() {
+        let pk_bytes = hex::decode("330b745d9da896f6f89f288633d25b4608d53c0a03f53336c5b03713f1a95559").unwrap();
+        let signed_bytes = hex::decode("f7d9e1b08c814154f60760e9cb7cd3c3618743f665b7af1661e9dbbab3ee005d7a4314fb992cade8a048bca5b5d27170450ca5ce87cfffb36d43a95d34b62c00").unwrap();
+
+        let pub_key = PublicKey::from_raw_ed25519(&pk_bytes).unwrap();
+        let info = Info::new(pub_key, Power::new(0));
+
+        assert_eq!(
+            info.verify_signature("test message".as_bytes(), &signed_bytes),
+            true
+        );
+
+        assert_eq!(
+            info.verify_signature("wrong test message".as_bytes(), &signed_bytes),
+            false
+        );
     }
 }

--- a/src/types/validator.rs
+++ b/src/types/validator.rs
@@ -17,9 +17,9 @@ use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use signatory::{
     ed25519,
-    signature::{Signature, Verifier},
+    signature::{Signature},
 };
-use signatory_dalek::Ed25519Verifier;
+use ed25519_dalek::Verifier;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 use std::marker::PhantomData;
@@ -183,9 +183,10 @@ impl Validator for Info {
     /// public key.
     fn verify_signature(&self, sign_bytes: &[u8], signature: &[u8]) -> bool {
         if let Some(pk) = &self.pub_key.ed25519() {
-            let verifier = Ed25519Verifier::from(pk);
-            if let Ok(sig) = ed25519::Signature::from_bytes(signature) {
-                return verifier.verify(sign_bytes, &sig).is_ok();
+            if let Ok(pk) = ed25519_dalek::PublicKey::from_bytes(&pk.into_bytes()) {
+                if let Ok(sig) = ed25519::Signature::from_bytes(signature) {
+                    return pk.verify(sign_bytes, &sig).is_ok()
+                }
             }
         }
         false


### PR DESCRIPTION
### Issue
while building the quantum tunnel with my current project, the dependencies of quantum tunnel fail. It's a long dep-chain tbh, so I'll skip the details...
In the nutshell I need to upgrade the signatory + substrate libs, to move on with the `syn` and `sp-core` packages. (I can get the whole tree description dep if needed)

UPDATE: based on the conversation in this PR, it's better to remove signatory dependency in favor of direct calls to selected crypto libs. Tendermint performed similar [migration](https://github.com/informalsystems/tendermint-rs/pull/522/files).
Also, ed25519 was moved to a [separate package](https://docs.rs/crate/signatory-dalek/0.99.0), so keeping signatory isn't that useful anymore.

## Test plan
Tests in `pubkey.rs` and `validator.rs` (added one extra) are sufficient to confirm that there are no functional changes introduced (tests pass before and after this PR).

## Follow-up
Since this repo is being used by quantum tunnel and wormhole repos I [made appropriate changes](https://pastebin.mkaczanowski.pro/?5626b8890b77745a#6Qgvx2oUyGwbf2CrphLG4m2MUQukm1m29tAj8bSqhDvC), removing the signatory from the deps. However, there are other problems related to the obligatory `substrate` (currently code doesn't compile, unless substrate deps are updated).
So, I can't confirm the quantum-tunnel works after those changes, because of substrate lib upgrade issues.

Taken the unittests are in place I think the PR should work fine