### PR TITLE
sync tendermint types to 0.17.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "tendermint_light_client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anomaly",
  "base64",

--- a/src/serialization/custom.rs
+++ b/src/serialization/custom.rs
@@ -32,14 +32,13 @@ where
 {
     #[derive(Deserialize)]
     struct Parts {
-        #[serde(with = "super::from_str")]
         total: u64,
         hash: String,
     }
     #[derive(Deserialize)]
     struct BlockId {
         hash: String,
-        parts: Parts,
+        part_set_header: Parts,
     }
     if let Some(tmp_id) = <Option<BlockId>>::deserialize(deserializer)? {
         if tmp_id.hash.is_empty() {
@@ -48,12 +47,12 @@ where
             Ok(Some(block::id::Id {
                 hash: Hash::from_str(&tmp_id.hash)
                     .map_err(|err| D::Error::custom(format!("{}", err)))?,
-                parts: if tmp_id.parts.hash.is_empty() {
+                part_set_header: if tmp_id.part_set_header.hash.is_empty() {
                     None
                 } else {
                     Some(parts::Header {
-                        total: tmp_id.parts.total,
-                        hash: Hash::from_str(&tmp_id.parts.hash)
+                        total: tmp_id.part_set_header.total,
+                        hash: Hash::from_str(&tmp_id.part_set_header.hash)
                             .map_err(|err| D::Error::custom(format!("{}", err)))?,
                     })
                 },

--- a/src/types/amino/mod.rs
+++ b/src/types/amino/mod.rs
@@ -45,7 +45,7 @@ impl From<&block::id::Id> for BlockId {
         let bid_hash = bid.hash.as_bytes();
         BlockId::new(
             bid_hash.to_vec(),
-            bid.parts.as_ref().map(PartsSetHeader::from),
+            bid.part_set_header.as_ref().map(PartsSetHeader::from),
         )
     }
 }
@@ -201,7 +201,7 @@ impl TryFrom<&vote::Vote> for Vote {
             round: vote.round as i64,
             block_id: vote.block_id.as_ref().map(|block_id| BlockId {
                 hash: block_id.hash.as_bytes().to_vec(),
-                parts_header: block_id.parts.as_ref().map(PartsSetHeader::from),
+                parts_header: block_id.part_set_header.as_ref().map(PartsSetHeader::from),
             }),
             timestamp: Some(TimeMsg::from(vote.timestamp)),
             validator_address: vote.validator_address.as_bytes().to_vec(),

--- a/src/types/block/commit.rs
+++ b/src/types/block/commit.rs
@@ -27,7 +27,6 @@ pub struct Commit {
     pub height: Height,
 
     /// Round
-    #[serde(with = "crate::serialization::from_str")]
     pub round: u64,
 
     /// Block ID

--- a/src/types/block/id.rs
+++ b/src/types/block/id.rs
@@ -30,13 +30,13 @@ pub struct Id {
     /// way to propagate a large file over a gossip network.
     ///
     /// <https://github.com/tendermint/tendermint/wiki/Block-Structure#partset>
-    pub parts: Option<parts::Header>,
+    pub part_set_header: Option<parts::Header>,
 }
 
 impl Id {
     /// Create a new `Id` from a hash byte slice
-    pub fn new(hash: Hash, parts: Option<parts::Header>) -> Self {
-        Self { hash, parts }
+    pub fn new(hash: Hash, part_set_header: Option<parts::Header>) -> Self {
+        Self { hash, part_set_header }
     }
 
     /// Get a shortened 12-character prefix of a block ID (ala git)

--- a/src/types/block/parts.rs
+++ b/src/types/block/parts.rs
@@ -6,7 +6,6 @@ use crate::types::hash::Hash;
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Header {
     /// Number of parts in this block
-    #[serde(with = "crate::serialization::from_str")]
     pub total: u64,
 
     /// Hash of the parts set header,


### PR DESCRIPTION
### Summary
The tendermint upgrade from 0.16 to 0.17 (https://crates.io/crates/tendermint/0.17.1) requires some type changes.

The Go code already reflects the changes:
https://github.com/tendermint/tendermint/blob/70bb8cc8b70dcb357e069ebe60b26a85c7994760/types/part_set.go#L94

What changed:
* `parts` renamed to `part_set_header`
* some "string wrapped integers" are now just integers

### Test plan
Tested with wormhole bridge (simulations work with patched repo)